### PR TITLE
4.1.5-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.3-beta.1
+* Updated the history page so that it will automatically refresh when changes are detected
+
 ## 4.1.2-beta.3
 * Updated Electron Forge to v7.6 to comply with Electron v34
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.4-beta.1
+* Fixed a bug that caused related goats not to be fetched for references (currently currently fetches related goats for references even if the references page is disabled)
+
 ## 4.1.3-beta.1
 * Updated the history page so that it will automatically refresh when changes are detected
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.5-beta.1
+* Added the ability to customize the text at the top of the kidding schedule
+
 ## 4.1.4-beta.1
 * Fixed a bug that caused related goats not to be fetched for references (currently currently fetches related goats for references even if the references page is disabled)
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "4.1.2-beta.3",
+  "version": "4.1.3-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "4.1.4-beta.1",
+  "version": "4.1.5-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "4.1.3-beta.1",
+  "version": "4.1.4-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/renderer/src/app/services/config/config.service.ts
+++ b/projects/renderer/src/app/services/config/config.service.ts
@@ -168,6 +168,15 @@ export class ConfigService {
   set kiddingSchedule(kiddingSchedule: boolean) {
     this.config = { kiddingSchedule: kiddingSchedule };
   }
+  get kiddingScheduleDescription(): string {
+    if (this.config['kiddingScheduleDescription']) {
+      return this.config['kiddingScheduleDescription'] as string;
+    }
+    return '';
+  }
+  set kiddingScheduleDescription(kiddingScheduleDescription: string) {
+    this.config = { kiddingScheduleDescription: kiddingScheduleDescription };
+  }
   get references(): boolean {
     return this.config['references'] as boolean ?? false;
   }

--- a/projects/renderer/src/app/windows/main/goats/goats.component.ts
+++ b/projects/renderer/src/app/windows/main/goats/goats.component.ts
@@ -2,10 +2,10 @@ import type { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { Component, ViewChild, type ElementRef } from '@angular/core';
 import type { Goat } from '../../../../../../shared/services/goat/goat.service';
 import { ADGAService } from '../../../services/adga/adga.service';
+import { ConfigService } from '../../../services/config/config.service';
 import { DiffService } from '../../../services/diff/diff.service';
 import { GoatService } from '../../../services/goat/goat.service';
 import { BuckFilter, DoeFilter } from '../elements/goat-lookup/goat-lookup.component';
-import { ConfigService } from '../../../services/config/config.service';
 
 @Component({
   selector: 'app-goats',
@@ -165,7 +165,7 @@ export class GoatsComponent {
 
       const ids: number[] = [];
       const goats: Goat[] = [];
-      (await Promise.all([this.goatService.getDoes(), this.goatService.getBucks()])).forEach(_goats => goats.push(..._goats));
+      (await Promise.all([this.goatService.getDoes(), this.goatService.getBucks(), this.goatService.getReferences()])).forEach(_goats => goats.push(..._goats));
       for (const goat of goats) {
         if (goat.damId && !ids.includes(goat.damId)) {
           ids.push(goat.damId);

--- a/projects/renderer/src/app/windows/main/history/history.component.ts
+++ b/projects/renderer/src/app/windows/main/history/history.component.ts
@@ -14,6 +14,8 @@ export class HistoryComponent implements OnInit {
   history?: History;
   async ngOnInit() {
     this.history = await this.gitService.getHistory();
+
+    this.gitService.onchange = async () => this.history = await this.gitService.getHistory();
   }
   formatBody(body: string) {
     body = body.replace(/"([^"]*)"/g, (match, p1) => `<span class="unsaved">"${this.marked.parseInline(p1.replaceAll('\\n', '\n'))}"</span>`);

--- a/projects/renderer/src/app/windows/main/kidding-schedule/kidding-schedule.component.html
+++ b/projects/renderer/src/app/windows/main/kidding-schedule/kidding-schedule.component.html
@@ -4,9 +4,20 @@
   <span
     class="list-group-item color-scheme-tertiary form-check form-switch form-check-reverse d-flex justify-content-center position-sticky top-0"
     style="min-height: auto; z-index: 1 !important;">
-    <label class="form-check-label" for="kiddingScheduleSwitch">Kidding Schedule: <span class="fw-bold text-success"
-        *ngIf="enabled">Enabled</span><span class="fw-bold text-danger" *ngIf="!enabled">Disabled</span></label>
-    <input class="form-check-input ms-1" type="checkbox" role="switch" id="kiddingScheduleSwitch" [(ngModel)]="enabled">
+    <label class="form-check-label" for="kiddingScheduleSwitch"><span [class.unsaved]="configService.isDirty('kiddingSchedule')">Kidding
+        Schedule: </span>
+      <span class="fw-bold text-success" *ngIf="configService.kiddingSchedule">Enabled</span><span class="fw-bold text-danger"
+        *ngIf="!configService.kiddingSchedule">Disabled</span></label>
+    <input class="form-check-input ms-1" type="checkbox" role="switch" id="kiddingScheduleSwitch"
+      [(ngModel)]="configService.kiddingSchedule">
+  </span>
+  <span class="list-group-item color-scheme-tertiary d-flex justify-content-center border-0"
+    style="min-height: auto; z-index: 1 !important; ">
+    <div class="input-group" [class.unsaved]="configService.isDirty('kiddingScheduleDescription')">
+      <span class="input-group-text">Kidding Schedule Description:</span>
+      <textarea type="text" class="form-control" [(ngModel)]="configService.kiddingScheduleDescription" markdown
+        suggestion="Click on a Goat Below For More Info"></textarea>
+    </div>
   </span>
   <span *ngIf="!breedings.length" class="list-group-item color-scheme-tertiary text-center">No Schedule Found!</span>
   <div *ngFor="let breeding of breedings; index as i" class="list-group-item row row-cols-3 color-scheme-tertiary justify-content-around"


### PR DESCRIPTION
## 4.1.5-beta.1
* Added the ability to customize the text at the top of the kidding schedule

## 4.1.4-beta.1
* Fixed a bug that caused related goats not to be fetched for references (currently currently fetches related goats for references even if the references page is disabled)

## 4.1.3-beta.1
* Updated the history page so that it will automatically refresh when changes are detected
