### PR TITLE
5.3.5-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.3.5-beta.2
+* Some minor changes to the Markdown rendering
+  * It now uses a different color when restoring markdown from the cache
+  * Fixed a bug causing the markdown to be double rendered
+
 ## 5.3.5-beta.1
 * Improved Markdown rendering
   * It now uses the built-in compiler to immediately show a rendered output, then it updates it with the gfm once downloaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.3.5-beta.3
+* Updated the marked dependency to match the one used in the live preview (v15.0.11)
+
 ## 5.3.5-beta.2
 * Some minor changes to the Markdown rendering
   * It now uses a different color when restoring markdown from the cache

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.3.5-beta.2",
+  "version": "5.3.5-beta.3",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",
@@ -61,7 +61,7 @@
     "deep-object-diff": "^1.1.9",
     "electron-squirrel-startup": "^1.0.1",
     "fs-extra": "^11.2.0",
-    "marked": "^14.1.2",
+    "marked": "^15.0.11",
     "rxjs": "~7.8.0",
     "semver": "^7.6.2",
     "simple-git": "^3.24.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.3.5-beta.1",
+  "version": "5.3.5-beta.2",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/renderer/src/app/directives/markdown/markdown.directive.ts
+++ b/projects/renderer/src/app/directives/markdown/markdown.directive.ts
@@ -81,11 +81,10 @@ export class MarkdownDirective implements OnInit {
             this.oldValue = value;
           } catch (error) {
             console.warn('Failed to render markdown', error);
-            this.markdownEl.innerHTML = this.markedService.parse(value);
           }
         } else {
-          this.iconEl.classList.remove('text-danger', 'text-warning');
-          this.iconEl.classList.add('text-success');
+          this.iconEl.classList.remove('text-danger', 'text-warning', 'text-success');
+          this.iconEl.classList.add('text-info');
           this.markdownEl.style.display = 'block';
           this.el.nativeElement.style.display = 'none';
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8699,10 +8699,10 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-marked@^14.1.2:
-  version "14.1.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-14.1.2.tgz#3cbc26b2d6832be32b75ae0746e0968c781b6156"
-  integrity sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==
+marked@^15.0.11:
+  version "15.0.11"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-15.0.11.tgz#08a8d12c285e16259e44287b89ce0d871c9d55e8"
+  integrity sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==
 
 matcher@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## 5.3.5-beta.3
* Updated the marked dependency to match the one used in the live preview (v15.0.11)

## 5.3.5-beta.2
* Some minor changes to the Markdown rendering
  * It now uses a different color when restoring markdown from the cache
  * Fixed a bug causing the markdown to be double rendered
