### PR TITLE
5.5.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.5.0-beta.1
+* Added CDCB Support!
+  * This allows you to sync your milk test data straight from the CDCB website
+  * Currently, all lactations from milk test are synced, as well as the individual tests and the performance of each lactation (Somatic cell count is not currently synced)
+  * This is currently only available for does, but may be added for pedigrees in the future
+
 ## 5.4.4-beta.1
 * Fixed a bug causing an unregistered goat to become locked
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 5.5.0-beta.2
+* Optimized lactation syncing by fetching the tests for each lactation in parallel
+  * This significantly reduces the time it takes to sync lactations, especially for goats with many lactations (originally ~7 seconds for a goat with 7 lactations, now ~3 seconds)
+
 ## 5.5.0-beta.1
 * Added CDCB Support!
   * This allows you to sync your milk test data straight from the CDCB website
   * Currently, all lactations from milk test are synced, as well as the individual tests and the performance of each lactation (Somatic cell count is not currently synced)
   * This is currently only available for does, but may be added for pedigrees in the future
+
+## 5.4.5-beta.1
+* The history page now color-codes any numbers or boolean (true/false) values
 
 ## 5.4.4-beta.1
 * Fixed a bug causing an unregistered goat to become locked

--- a/angular.tsconfig.json
+++ b/angular.tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "declaration": false,
     "experimentalDecorators": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.4.4-beta.1",
+  "version": "5.5.0-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",
@@ -55,7 +55,7 @@
     "@angular/platform-browser": "^19.0.6",
     "@angular/platform-browser-dynamic": "^19.0.6",
     "@angular/router": "^19.0.6",
-    "adga": "^3.5.0",
+    "adga": "^3.7.0-beta.1",
     "axios": "^1.7.9",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.0-beta.1",
+  "version": "5.5.0-beta.2",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/main/src/app/services/adga/adga.service.ts
+++ b/projects/main/src/app/services/adga/adga.service.ts
@@ -1,13 +1,16 @@
 import ADGA from 'adga';
+import CDCB, { LactationType } from 'adga/cdcb';
 import { AxiosError } from 'axios';
 import { BrowserWindow, app, safeStorage } from 'electron';
 import { ensureFile, ensureFileSync, readFile, readFileSync, readJSON, readJSONSync, writeFile, writeJSON } from 'fs-extra';
 import { join } from 'path';
 import { ADGAService as ADGAServiceType, type Account } from '../../../../../shared/services/adga/adga.service';
+import type { LactationRecord } from '../../../../../shared/services/goat/goat.service';
 import type { BackendService } from '../../../../../shared/shared.module';
 
 export class ADGAService {
   adga?: ADGA;
+  cdcb: CDCB;
   accountPath = join(app.getPath('userData'), 'ADGA Account');
   blacklistPath = join(app.getPath('userData'), 'ADGA Blacklist');
   account?: Account;
@@ -131,6 +134,60 @@ export class ADGAService {
         return this.handleError(err);
       }
     },
+    getCDCBGoat: async (_event, normalizeId) => {
+      try {
+        return await this.cdcb.searchAnimal(normalizeId);
+      } catch (err) {
+        console.warn('Error Fetching CDCB Goat:', err);
+        return this.handleError(err);
+      }
+    },
+    getLactations: async (_event, usdaId, animalKey) => {
+      try {
+        const records: LactationRecord[] = [];
+        const lactations = await this.cdcb.getAnimalLactations(usdaId, animalKey);
+        for (const lactation of lactations) {
+          const lactationTests = await this.cdcb.getLactationsTestDate(usdaId, animalKey, lactation.calvPdate, lactation.herdCode);
+          const stats: LactationRecord['stats'] = { milk: {}, butterfat: {}, protein: {} };
+          for (const stat of lactationTests.lactationStds) {
+            if (stat.typeName === 'Actual') {
+              stats.milk.projected = stat.mlk;
+              stats.butterfat.projected = stat.fat;
+              stats.protein.projected = stat.pro;
+            } else if (stat.typeName === 'Standard') {
+              stats.milk.achieved = stat.mlk;
+              stats.butterfat.achieved = stat.fat;
+              stats.protein.achieved = stat.pro;
+            }
+          }
+          const tests: LactationRecord['tests'] = [];
+          for (const test of lactationTests.testDates) {
+            tests.push({
+              testNumber: test.testNo,
+              testDate: test.testDate,
+              milk: test.milk,
+              butterfatPct: test.fatPct,
+              proteinPct: test.proPct,
+              daysInMilk: test.dim,
+            });
+
+          }
+          const record: LactationRecord = {
+            startDate: lactation.freshDate,
+            isCurrent: lactation.lt === LactationType.IN_PROGRESS,
+            lactationNumber: lactation.lactNum,
+            daysInMilk: lactation.dim,
+            stats: stats,
+            tests: tests,
+          };
+          records.unshift(record);
+        }
+        return records;
+      } catch (err) {
+        console.warn('Error Fetching Lactations:', err);
+        return this.handleError(err);
+      }
+    },
     lookupGoatsById: async (_event, normalizeId) => {
       if (!this.adga) {
         return this.noADGAMessage;
@@ -185,6 +242,7 @@ export class ADGAService {
     },
   };
   constructor() {
+    this.cdcb = new CDCB();
     const init = () => {
       try {
         this.account = this.readAccountSync();

--- a/projects/main/tsconfig.json
+++ b/projects/main/tsconfig.json
@@ -2,14 +2,14 @@
   "compilerOptions": {
     "target": "ES6",
     "allowJs": true,
-    "module": "commonjs",
+    "module": "node16",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
     "sourceMap": true,
     "baseUrl": ".",
     "outDir": "../../dist/main",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "resolveJsonModule": true,
     "paths": {
       "*": [

--- a/projects/preload/src/app/app/services/adga/adga.service.ts
+++ b/projects/preload/src/app/app/services/adga/adga.service.ts
@@ -8,6 +8,8 @@ export const ADGAService: ADGAServiceType = {
   getOwnedGoats: () => ipcRenderer.invoke('adga:getOwnedGoats'),
   getGoat: (id) => ipcRenderer.invoke('adga:getGoat', id),
   getGoats: (ids) => ipcRenderer.invoke('adga:getGoats', ids),
+  getCDCBGoat: (normalizeId) => ipcRenderer.invoke('adga:getCDCBGoat', normalizeId),
+  getLactations: (usdaId, animalKey) => ipcRenderer.invoke('adga:getLactations', usdaId, animalKey),
   onchange: (callback) => ipcRenderer.on('adga:change', () => callback()),
   lookupGoatsById: (normalizeId) => ipcRenderer.invoke('adga:lookupGoatsById', normalizeId),
   lookupGoatsByName: (name) => ipcRenderer.invoke('adga:lookupGoatsByName', name),

--- a/projects/renderer/src/app/services/adga/adga.service.ts
+++ b/projects/renderer/src/app/services/adga/adga.service.ts
@@ -56,6 +56,8 @@ export class ADGAService {
     });
     return parsedGoat;
   }
+  getCDCBGoat = window.electron.adga.getCDCBGoat;
+  getLactations = window.electron.adga.getLactations;
   set onchange(callback: () => void) {
     window.electron.adga.onchange(callback);
   }

--- a/projects/renderer/src/app/services/diff/diff.service.ts
+++ b/projects/renderer/src/app/services/diff/diff.service.ts
@@ -90,6 +90,7 @@ export class DiffService {
     'ilenesrascals': 'IlenesRascals',
     'teachmesomethin\'': 'TeachMeSomethin\'',
     'justn\'smoke': 'Justn\'Smoke',
+    'redhouse': 'RedHouse',
   };
 
   private parseCase(word: string) {

--- a/projects/renderer/src/app/windows/goat/elements/goat/goat.component.html
+++ b/projects/renderer/src/app/windows/goat/elements/goat/goat.component.html
@@ -9,11 +9,14 @@
       data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false" online-only>
       <span class="visually-hidden">Toggle Dropdown</span>
     </button>
-    <ul #dropdown class="dropdown-menu color-scheme-quaternary">
+    <ul #dropdown class="dropdown-menu color-scheme-quaternary" style="width: 125%">
       <li><button type="button" class="dropdown-item btn color-scheme-quaternary" [disabled]="syncingDetails" (click)="syncDetails()">Sync
           Details <i class="bi bi-arrow-repeat float-end" [class.spin]="syncingDetails"></i></button></li>
       <li><button type="button" class="dropdown-item btn color-scheme-quaternary" [disabled]="syncingLA" (click)="syncLA()">Sync LA <i
             class="bi bi-arrow-repeat float-end" [class.spin]="syncingLA"></i></button></li>
+      <li><button type="button" class="dropdown-item btn color-scheme-quaternary" [disabled]="syncingLactations"
+          (click)="syncLactations()">Sync Lactations <i class="bi bi-arrow-repeat float-end" [class.spin]="syncingLactations"></i></button>
+      </li>
       <li><button type="button" class="dropdown-item btn color-scheme-quaternary" [disabled]="syncingAwards" (click)="syncAwards()">Sync
           Awards <i class="bi bi-arrow-repeat float-end" [class.spin]="syncingAwards"></i></button></li>
       <!--
@@ -158,7 +161,7 @@
     </div>
     <div class="mb-3 col">
       <button class="btn btn-secondary w-100 color-scheme-quaternary" type="button" data-bs-toggle="collapse" data-bs-target="#linear"
-        aria-expanded="false" aria-controls="linear" [class.unsaved]="false"> Linear Appraisals <i class="bi bi-clipboard-data"></i>
+        aria-expanded="false" aria-controls="linear" [class.unsaved]="false"> Linear Appraisals <i class="bi bi-clipboard2-data"></i>
       </button>
       <!--<div class="collapse p-3 color-scheme-secondary" id="linear">
         <div class="row">
@@ -241,8 +244,97 @@
       </div>
     </div>
     <div class="mb-3 col">
+      <button class="btn btn-secondary w-100 color-scheme-quaternary" type="button" data-bs-toggle="collapse"
+        data-bs-target="#lactationHistory" aria-expanded="false" aria-controls="lactationHistory" [class.unsaved]="false"> Lactation History
+        <i class="bi bi-clipboard2-pulse"></i>
+      </button>
+      <div class="collapse p-3 color-scheme-secondary" id="lactationHistory">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th scope="col">Start Date</th>
+              <th scope="col">Lactation</th>
+              <th scope="col" tooltip="Days in Milk">DIM</th>
+              <th scope="col" tooltip="Achieved/Projected (lbs)">Milk</th>
+              <th scope="col" tooltip="Achieved/Projected (lbs)">Butter Fat</th>
+              <th scope="col" tooltip="Achieved/Projected (lbs)">Protein</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngIf="!lactationRecords?.length">
+              <td colspan="100" class="text-center"> No Lactation History Found </td>
+            </tr>
+            <tr *ngFor="let record of lactationRecords; index as i">
+              <th scope="row" [class.fst-italic]="record.isCurrent" [class.fw-bold]="record.isCurrent"
+                [tooltip]="record.isCurrent ? 'Active Lactation' : ''">{{record.startDate | longDate}}
+              </th>
+              <td>
+                {{record.lactationNumber}}
+              </td>
+              <td>
+                {{record.daysInMilk}}
+              </td>
+              <td>
+                {{record.stats?.milk?.achieved}} / {{record.stats?.milk?.projected}}
+              </td>
+              <td>
+                {{record.stats?.butterfat?.achieved}} / {{record.stats?.butterfat?.projected}}
+              </td>
+              <td>
+                {{record.stats?.protein?.achieved}} / {{record.stats?.protein?.projected}}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="mb-3 col">
+      <button class="btn btn-secondary w-100 color-scheme-quaternary" type="button" data-bs-toggle="collapse"
+        data-bs-target="#currentLactation" aria-expanded="false" aria-controls="currentLactation" [class.unsaved]="false"> Current Lactation
+        <i class="bi bi-clipboard-pulse"></i>
+      </button>
+      <div class="collapse p-3 color-scheme-secondary" id="currentLactation">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th scope="col">Test #:</th>
+              <th scope="col">Test Date</th>
+              <th scope="col" tooltip="Days in Milk">DIM</th>
+              <th scope="col">Milk</th>
+              <th scope="col" tooltip="Butter Fat Percent">Fat Pct.</th>
+              <th scope="col" tooltip="Protein Percent">Protein Pct.</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngIf="!currentLactation?.tests?.length">
+              <td colspan="100" class="text-center"> No Tests Found For the Current Lactation </td>
+            </tr>
+            <tr *ngFor="let test of currentLactation?.tests; index as i">
+              <th scope="row">{{test.testNumber}}
+              </th>
+              <td>
+                {{test.testDate | longDate}}
+              </td>
+              <td>
+                {{test.daysInMilk}}
+              </td>
+              <td>
+                {{test.milk}}
+              </td>
+              <td>
+                {{test.butterfatPct}}%
+              </td>
+              <td>
+                {{test.proteinPct}}%
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="mb-3 col">
       <button class="btn btn-secondary w-100 color-scheme-quaternary" type="button" data-bs-toggle="collapse" data-bs-target="#awards"
-        aria-expanded="false" aria-controls="awards" [class.unsaved]="false"> Awards <i class="bi bi-clipboard2-data"></i>
+        aria-expanded="false" aria-controls="awards" [class.unsaved]="false"> Awards <i class="bi bi-award"></i>
       </button>
       <div class="collapse p-3 color-scheme-secondary" id="awards">
         <table class="table table-hover">

--- a/projects/renderer/src/app/windows/goat/elements/goat/goat.component.ts
+++ b/projects/renderer/src/app/windows/goat/elements/goat/goat.component.ts
@@ -58,7 +58,7 @@ export class GoatComponent implements OnInit {
     } else {
       shown = true;
     }
-    await Promise.all([this.syncDetails(), this.syncLA(), this.syncAwards()]);
+    await Promise.all([this.syncDetails(), this.syncLA(), this.syncLactations(), this.syncAwards()]);
     if (this.dropdown.nativeElement.classList.contains('show')) {
       if (!shown) {
         this.dropdownButton.nativeElement.click();
@@ -90,6 +90,22 @@ export class GoatComponent implements OnInit {
       await this.adgaService.handleError(error as Error, 'Error Syncing Linear Appraisal!');
     } finally {
       this.syncingLA = false;
+    }
+  }
+  syncingLactations = false;
+  async syncLactations() {
+    this.syncingLactations = true;
+    try {
+      if (!this.goat.usdaId || !this.goat.usdaKey) {
+        const cdcbGoat = await this.adgaService.getCDCBGoat(this.goat.normalizeId!);
+        this.goat = { usdaId: cdcbGoat.animalId, usdaKey: cdcbGoat.animKey };
+      }
+      const lactationRecords = await this.adgaService.getLactations(this.goat.usdaId!, this.goat.usdaKey!);
+      this.goat.lactationRecords = lactationRecords;
+    } catch (error) {
+      await this.adgaService.handleError(error as Error, 'Error Syncing Lactations!');
+    } finally {
+      this.syncingLactations = false;
     }
   }
   syncingAwards = false;
@@ -203,6 +219,15 @@ export class GoatComponent implements OnInit {
   }
   set linearAppraisals(linear) {
     this.goat = { linearAppraisals: linear };
+  }
+  get lactationRecords() {
+    return this.goat.lactationRecords;
+  }
+  set lactationRecords(lactationRecords) {
+    this.goat = { lactationRecords: lactationRecords };
+  }
+  get currentLactation() {
+    return this.goat.lactationRecords?.find(lactation => lactation.isCurrent);
   }
   get pet(): boolean | undefined {
     return this.goat.pet;

--- a/projects/renderer/src/app/windows/main/goats/goats.component.ts
+++ b/projects/renderer/src/app/windows/main/goats/goats.component.ts
@@ -76,9 +76,22 @@ export class GoatsComponent {
             let goat: Goat;
             let linearAppraisals: Goat['linearAppraisals'];
             let awards: Goat['awards'];
-            await Promise.all([(async () => goat = await this.adgaService.getGoat(doe.id!))(), (async () => linearAppraisals = await this.adgaService.getLinearAppraisal(doe.id!))(), (async () => awards = await this.adgaService.getAwards(doe.id!))()]);
+            let usdaId = doe.usdaId;
+            let usdaKey = doe.usdaKey;
+            let lactationRecords: Goat['lactationRecords'];
+            await Promise.all([(async () => goat = await this.adgaService.getGoat(doe.id!))(), (async () => linearAppraisals = await this.adgaService.getLinearAppraisal(doe.id!))(), (async () => {
+              if (!usdaId! || !usdaKey!) {
+                const cdcbGoat = await this.adgaService.getCDCBGoat(doe.normalizeId!);
+                usdaId = cdcbGoat.animalId;
+                usdaKey = cdcbGoat.animKey;
+              }
+              lactationRecords = await this.adgaService.getLactations(usdaId, usdaKey);
+            })(), (async () => awards = await this.adgaService.getAwards(doe.id!))()]);
             does![i] = this.diffService.softMerge(doe, goat!);
             does![i].linearAppraisals = linearAppraisals;
+            does![i].usdaId = usdaId;
+            does![i].usdaKey = usdaKey;
+            does![i].lactationRecords = lactationRecords;
             does![i].awards = awards;
           }
         }

--- a/projects/renderer/src/app/windows/main/history/history.component.ts
+++ b/projects/renderer/src/app/windows/main/history/history.component.ts
@@ -19,6 +19,8 @@ export class HistoryComponent implements OnInit {
   }
   formatBody(body: string) {
     body = body.replace(/"([^"]*)"/g, (match, p1) => `<span class="unsaved">"${this.marked.parseInline(p1.replaceAll('\\n', '\n'))}"</span>`);
+    body = body.replace(/\b(\d+(\.\d+)?)\b/g, (match) => `<span class="text-info-emphasis">${match}</span>`);
+    body = body.replace(/\b(true|false)\b/g, (match) => `<span class="text-danger-emphasis">${match}</span>`);
     return body;
   }
 }

--- a/projects/shared/services/adga/adga.service.d.ts
+++ b/projects/shared/services/adga/adga.service.d.ts
@@ -1,4 +1,6 @@
 import type { Awards, Goat, Goats, LinearAppraisal, OwnedGoats } from 'adga';
+import type { Animal } from 'adga/cdcb';
+import type { LactationRecord } from '../goat/goat.service';
 
 export interface ADGAService {
   getAccount: () => Promise<Account>;
@@ -7,6 +9,8 @@ export interface ADGAService {
   getOwnedGoats: () => Promise<OwnedGoats['result']>;
   getGoat: (id: number) => Promise<Goat['result']>;
   getGoats: (ids: number[]) => Promise<Goats['result']>;
+  getCDCBGoat: (normalizeId: string) => Promise<Animal>;
+  getLactations: (usdaId: string, animalKey: number) => Promise<LactationRecord[]>;
   onchange: (callback: () => void) => void;
   lookupGoatsById: (normalizeId: string) => Promise<Goats['result']['items']>;
   lookupGoatsByName: (name: string) => Promise<Goats['result']['items']>;

--- a/projects/shared/services/goat/goat.service.d.ts
+++ b/projects/shared/services/goat/goat.service.d.ts
@@ -1,3 +1,5 @@
+import type { LAClassifications } from 'adga';
+
 export interface GoatService {
   getDoes: () => Promise<Goat[]>;
   setDoes: (does: Goat[]) => Promise<void>;
@@ -53,7 +55,39 @@ export type Goat = Partial<{
     awardYear: number;
     awardCount: number;
   }>[];
+  usdaId: string;
+  usdaKey: number;
+  lactationRecords: LactationRecord[];
 }>;
+export type LactationRecord = Partial<{
+  startDate: string;
+  isCurrent: boolean;
+  daysInMilk: string;
+  lactationNumber: string;
+  stats: Partial<{
+    milk: Partial<{
+      achieved: string;
+      projected: string;
+    }>;
+    butterfat: Partial<{
+      achieved: string;
+      projected: string;
+    }>;
+    protein: Partial<{
+      achieved: string;
+      projected: string;
+    }>;
+  }>;
+  tests: Partial<{
+    testNumber: number;
+    daysInMilk: string;
+    milk: string;
+    butterfatPct: string;
+    proteinPct: string;
+    testDate: string;
+  }>[];
+}>;
+
 export type GoatType = 'doe' | 'buck' | 'reference' | 'related' | 'for-sale';
 export type Kidding = Partial<{
   dam: string;

--- a/projects/shared/shared.module.d.ts
+++ b/projects/shared/shared.module.d.ts
@@ -34,6 +34,7 @@ type WithoutNonPromises<T> = {
 };
 
 export type BackendService<T> = {
+  //@ts-expect-error
   [K in keyof WithoutOnKeys<WithoutNonPromises<T>>]: T[K] extends (...args: infer A) => any ? (event: IpcMainEvent, ...args: A) => ReturnType<T[K]> : never;
 };
 export type BackendSharedModule = Record<keyof SharedModule, BackendService<SharedModule[keyof SharedModule]>>;

--- a/projects/shared/tsconfig.json
+++ b/projects/shared/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "target": "es2022",
+  }
+}

--- a/scripts/version.ts
+++ b/scripts/version.ts
@@ -2,4 +2,5 @@ import { readJSONSync, writeJSONSync } from 'fs-extra';
 
 const packageJson = readJSONSync('package.json');
 packageJson.version = packageJson.version.split('-')[0];
+packageJson.dependencies.adga = packageJson.dependencies.adga.split('-')[0];
 writeJSONSync('package.json', packageJson, { spaces: 2 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,10 +4372,10 @@ acorn@^8.14.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
-adga@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/adga/-/adga-3.5.0.tgz#a0d74efc9a29e5b99051410d1bdced1be4f8c7c0"
-  integrity sha512-K1Sz9WErzDdQ/XiX7hPmpKEUWQpZx/fxjGWszVI0TxX7ZrylJqTN7DezTuEcQgRobnok/ywEWsahKDDvAZDi3w==
+adga@^3.7.0-beta.1:
+  version "3.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/adga/-/adga-3.7.0-beta.1.tgz#c7c9dcad5c95148a5993b524cba08c61a400e5a5"
+  integrity sha512-OQ7e2PksrsqDvTo18tQqV+vcHglznzxjR8TWDPf0GJEka3v5MlY0SW+wvUluluOUf2zVVSu5DWFr/Ll65z31vQ==
   dependencies:
     axios "^0.26.1"
 


### PR DESCRIPTION
## 5.5.0-beta.2
* Optimized lactation syncing by fetching the tests for each lactation in parallel
  * This significantly reduces the time it takes to sync lactations, especially for goats with many lactations (originally ~7 seconds for a goat with 7 lactations, now ~3 seconds)

## 5.5.0-beta.1
* Added CDCB Support!
  * This allows you to sync your milk test data straight from the CDCB website
  * Currently, all lactations from milk test are synced, as well as the individual tests and the performance of each lactation (Somatic cell count is not currently synced)
  * This is currently only available for does, but may be added for pedigrees in the future

## 5.4.5-beta.1
* The history page now color-codes any numbers or boolean (true/false) values
