### PR TITLE
5.5.4-beta.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,16 +63,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Install Sharp Libraries (Mac)
-        if: matrix.os == 'macos-latest'
-        run: |
-          yarn add @img/sharp-libvips-darwin-arm64 @img/sharp-libvips-darwin-x64 --ignore-platform
-
-      - name: Install Sharp Libraries (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          yarn add @img/sharp-win32-arm64 @img/sharp-win32-ia32 @img/sharp-win32-x64 --ignore-platform
-
       - name: Build Project (Mac)
         if: matrix.os == 'macos-latest'
         run: yarn package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,6 @@ jobs:
 
       - run: yarn install
 
-      - name: Install Sharp Libraries
-        run: |
-          yarn add @img/sharp-libvips-darwin-arm64 @img/sharp-libvips-darwin-x64 --ignore-platform
-
       - name: Fix version
         if: github.ref_name == 'main'
         run: yarn fix-version
@@ -49,10 +45,6 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - run: yarn install
-
-      - name: Install Sharp Libraries
-        run: |
-          yarn add @img/sharp-win32-arm64 @img/sharp-win32-ia32 @img/sharp-win32-x64 --ignore-platform
 
       - name: Fix version
         if: github.ref_name == 'main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.3-beta.4
+* Removed the extra dependencies that were downloaded manually for Mac as they caused issues when constructing the `universal` build of the app
+* Fully reverted `5.5.3-beta.2` as it was not needed
+
 ## 5.5.3-beta.3
 * Identified the root cause of the bug, which actually was caused by the lactation history update.
 * I am going to keep these previous fixes though, as they are still useful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.4-beta.1
+* The history page now limits the changes displayed to 30 lines
+  * This makes it significantly easier to navigate - the full list of changes can still be viewed by clicking
+
 ## 5.5.3-beta.4
 * Removed the extra dependencies that were downloaded manually for Mac as they caused issues when constructing the `universal` build of the app
 * Fully reverted `5.5.3-beta.2` as it was not needed

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.3-beta.3",
+  "version": "5.5.3-beta.4",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.3-beta.4",
+  "version": "5.5.4-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/renderer/src/app/windows/main/history/history.component.html
+++ b/projects/renderer/src/app/windows/main/history/history.component.html
@@ -1,4 +1,5 @@
 <h1 class="text-center">History</h1>
+<h6 class="text-center">(Click a change to expand details)</h6>
 <br>
 <table class="table table-hover border container mb-0" style="table-layout: fixed;" *ngIf="history?.local?.total || !history">
   <colgroup>
@@ -57,7 +58,7 @@
     </tr>
   </thead>
   <tbody>
-    <tr *ngFor="let entry of (history?.remote?.all)">
+    <tr *ngFor="let entry of (history?.remote?.all)" (click)="bodyText.classList.toggle('text-truncate')" style="cursor: pointer">
       <th scope="row">
         {{entry.date | date:'MMM dd, yyyy \'at\' hh:mm a'}}
       </th>
@@ -65,7 +66,7 @@
         {{entry.message}}
       </td>
       <td>
-        <p [innerHTML]="formatBody(entry.body)" style="white-space: pre-wrap;"></p>
+        <div [innerHTML]="formatBody(entry.body)" style="white-space: pre-wrap;" #bodyText class="text-truncate"></div>
       </td>
       <td>
         <a href="mailto:{{entry.author_email}}">{{entry.author_name}}</a>

--- a/projects/renderer/src/app/windows/main/history/history.component.scss
+++ b/projects/renderer/src/app/windows/main/history/history.component.scss
@@ -13,3 +13,11 @@
 :host ::ng-deep .unsaved>a {
   color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1)) !important;
 }
+
+.text-truncate {
+  display: -webkit-box;
+  -webkit-line-clamp: 20;
+  line-clamp: 20;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}


### PR DESCRIPTION
## 5.5.4-beta.1
* The history page now limits the changes displayed to 30 lines
  * This makes it significantly easier to navigate - the full list of changes can still be viewed by clicking

## 5.5.3-beta.4
* Removed the extra dependencies that were downloaded manually for Mac as they caused issues when constructing the `universal` build of the app
* Fully reverted `5.5.3-beta.2` as it was not needed
