### PR TITLE
5.5.10-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.5.10-beta.1
+* Made markdown easier to read
+  * It now scrolls instead of wrapping
+  * The box description is now hidden when editing to provide more space for the markdown editor
+
 ## 5.5.9-beta.1
 * This is the proper implementation of the bug fixes in `5.5.6-beta.1`
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.9-beta.1",
+  "version": "5.5.10-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/renderer/src/app/directives/markdown/markdown.directive.ts
+++ b/projects/renderer/src/app/directives/markdown/markdown.directive.ts
@@ -17,10 +17,13 @@ export class MarkdownDirective implements OnInit {
   private markdownEl!: HTMLElement;
   private iconEl!: HTMLElement;
   private imageIconEl?: HTMLElement;
+  private descriptor?: HTMLElement;
 
   @Input({ alias: 'markdown-images', transform: booleanAttribute }) imagesUploads = false;
 
   async ngOnInit() {
+    this.descriptor = this.el.nativeElement.previousElementSibling as HTMLElement;
+
     this.markdownEl = this.el.nativeElement.ownerDocument.createElement('div');
     this.markdownEl.className = this.el.nativeElement.className + ' blocked-link' + ' text-center';
     this.markdownEl.style.cursor = 'text';
@@ -56,6 +59,7 @@ export class MarkdownDirective implements OnInit {
       bootstrap.Tooltip.getOrCreateInstance(this.imageIconEl);
     }
 
+    this.el.nativeElement.style.whiteSpace = 'pre';
     this.iconEl.addEventListener('click', () => this.appService.openMarkdown());
     this.el.nativeElement.insertAdjacentElement('beforebegin', this.iconEl);
     bootstrap.Tooltip.getOrCreateInstance(this.iconEl);
@@ -89,6 +93,7 @@ export class MarkdownDirective implements OnInit {
           this.el.nativeElement.style.display = 'none';
         }
         this.renderImages();
+        this.descriptor?.classList.remove('d-none');
       } catch (error) {
         this.iconEl.classList.remove('text-success', 'text-warning');
         this.iconEl.classList.add('text-danger');
@@ -99,6 +104,7 @@ export class MarkdownDirective implements OnInit {
   async hideMarkdown() {
     this.el.nativeElement.style.display = 'block';
     this.markdownEl.style.display = 'none';
+    this.descriptor?.classList.add('d-none');
     this.iconEl.classList.remove('text-success', 'text-danger', 'text-warning');
     this.imageIconEl?.classList.remove('text-success', 'text-danger');
     this.el.nativeElement.focus();


### PR DESCRIPTION
## 5.5.10-beta.1
* Made markdown easier to read
  * It now scrolls instead of wrapping
  * The box description is now hidden when editing to provide more space for the markdown editor
