### PR TITLE
5.5.10-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.5.10-beta.2
+* Reverted the scroll behavior as it wan't user-friendly
+* The box description is still hidden when editing to provide more space for the markdown editor
+
 ## 5.5.10-beta.1
 * Made markdown easier to read
   * It now scrolls instead of wrapping

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.10-beta.1",
+  "version": "5.5.10-beta.2",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/renderer/src/app/directives/markdown/markdown.directive.ts
+++ b/projects/renderer/src/app/directives/markdown/markdown.directive.ts
@@ -59,7 +59,6 @@ export class MarkdownDirective implements OnInit {
       bootstrap.Tooltip.getOrCreateInstance(this.imageIconEl);
     }
 
-    this.el.nativeElement.style.whiteSpace = 'pre';
     this.iconEl.addEventListener('click', () => this.appService.openMarkdown());
     this.el.nativeElement.insertAdjacentElement('beforebegin', this.iconEl);
     bootstrap.Tooltip.getOrCreateInstance(this.iconEl);


### PR DESCRIPTION
## 5.5.10-beta.2
* Reverted the scroll behavior as it wan't user-friendly
* The box description is still hidden when editing to provide more space for the markdown editor
