### PR TITLE
5.6.0-beta.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: yarn install
 
       - name: Fix version
-        if: github.ref_name == 'main'
+        if: github.base_ref == 'main'
         run: yarn fix-version
 
       - name: Rebuild dependencies
@@ -71,7 +71,7 @@ jobs:
         run: yarn install
 
       - name: Fix version
-        if: github.ref_name == 'main'
+        if: github.base_ref == 'main'
         run: yarn fix-version
 
       - name: Rebuild dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.6.0-beta.1
+* This is the same as `5.5.15-beta.1`, but as a recommended update to go with the accompanying update to the web-ui that allows for lactation data to be synced daily
+
 ## 5.5.15-beta.1
 * Fixed a bug causing the status checks to not fix the version correctly when merging into main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.5.15-beta.1
+* Fixed a bug causing the status checks to not fix the version correctly when merging into main
+
 ## 5.5.14-beta.1
 * Added support for multiple devices!
   * The app now checks for changes at boot and before publishing

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.15-beta.1",
+  "version": "5.6.0-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "5.5.14-beta.1",
+  "version": "5.5.15-beta.1",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
## 5.6.0-beta.1
* This is the same as `5.5.15-beta.1`, but as a recommended update to go with the accompanying update to the web-ui that allows for lactation data to be synced daily

## 5.5.15-beta.1
* Fixed a bug causing the status checks to not fix the version correctly when merging into main
