### PR TITLE
7.1.1-beta.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,4 +141,4 @@ jobs:
         uses: getsentry/action-release@v3
         with:
           environment: ${{ github.ref_name == 'main' && 'production' || 'beta' }}
-          release: ${{ steps.release.outputs.version }}
+          release: DigiGoat@${{ steps.release.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.1-beta.4
+* Added back an accidentally deleted script for the sourcemaps of the main process on MacOS
+* Updated release names to be Sentry compatible (i.e. `DigiGoat@7.1.1-beta.4` instead of just `7.1.1-beta.4`)
+
 ## 7.1.1-beta.3
 * Fixed a bug causing source maps to not upload correctly on MacOS
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "7.1.1-beta.3",
+  "version": "7.1.1-beta.4",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",
@@ -43,11 +43,12 @@
     "release": "ts-node ./scripts/release.ts",
     "fix-version": "ts-node ./scripts/version.ts",
     "rebuild": "tsc -m commonjs --esModuleInterop forge.config.ts && (echo '//GENERATED CODE, RUN `yarn rebuild` TO UPDATE\n' && cat forge.config.js) > forge.config.js.tmp && mv forge.config.js.tmp forge.config.js",
-    "sourcemap:renderer": "sentry-cli sourcemaps inject ./dist/renderer/browser && sentry-cli sourcemaps upload ./dist/renderer/browser --release $npm_package_version --dist $SENTRY_DIST",
-    "sourcemap:preload": "sentry-cli sourcemaps inject ./dist/preload && sentry-cli sourcemaps upload ./dist/preload --release $npm_package_version --dist $SENTRY_DIST",
-    "sourcemap:windows:main": "sentry-cli sourcemaps inject ./dist/main && sentry-cli sourcemaps upload ./dist/main --release %npm_package_version% --dist %SENTRY_DIST%",
-    "sourcemap:windows:renderer": "sentry-cli sourcemaps inject ./dist/renderer/browser && sentry-cli sourcemaps upload ./dist/renderer/browser --release %npm_package_version% --dist %SENTRY_DIST%",
-    "sourcemap:windows:preload": "sentry-cli sourcemaps inject ./dist/preload && sentry-cli sourcemaps upload ./dist/preload --release %npm_package_version% --dist %SENTRY_DIST%"
+    "sourcemap:main": "sentry-cli sourcemaps inject ./dist/main && sentry-cli sourcemaps upload ./dist/main --release \"DigiGoat@$npm_package_version\" --dist $SENTRY_DIST",
+    "sourcemap:renderer": "sentry-cli sourcemaps inject ./dist/renderer/browser && sentry-cli sourcemaps upload ./dist/renderer/browser --release \"DigiGoat@$npm_package_version\" --dist $SENTRY_DIST",
+    "sourcemap:preload": "sentry-cli sourcemaps inject ./dist/preload && sentry-cli sourcemaps upload ./dist/preload --release \"DigiGoat@$npm_package_version\" --dist $SENTRY_DIST",
+    "sourcemap:windows:main": "sentry-cli sourcemaps inject ./dist/main && sentry-cli sourcemaps upload ./dist/main --release \"DigiGoat@%npm_package_version%\" --dist %SENTRY_DIST%",
+    "sourcemap:windows:renderer": "sentry-cli sourcemaps inject ./dist/renderer/browser && sentry-cli sourcemaps upload ./dist/renderer/browser --release \"DigiGoat@%npm_package_version%\" --dist %SENTRY_DIST%",
+    "sourcemap:windows:preload": "sentry-cli sourcemaps inject ./dist/preload && sentry-cli sourcemaps upload ./dist/preload --release \"DigiGoat@%npm_package_version%\" --dist %SENTRY_DIST%"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## 7.1.1-beta.4
* Added back an accidentally deleted script for the sourcemaps of the main process on MacOS
* Updated release names to be Sentry compatible (i.e. `DigiGoat@7.1.1-beta.4` instead of just `7.1.1-beta.4`)
