### PR TITLE
7.1.1-beta.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release app
 on:
-  workflow_dispatch:
   push:
     branches: [main, beta]
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,3 +142,7 @@ jobs:
         with:
           environment: ${{ github.ref_name == 'main' && 'production' || 'beta' }}
           release: DigiGoat@${{ steps.release.outputs.version }}
+          set_commits: 'manual'
+          commit: ${{ github.sha }}
+          previous_commit: ${{ github.event.before }}
+          repo: DigiGoat/client-app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.1-beta.6
+* Started tracing all IPC calls with Sentry to help identify performance bottlenecks
+  * With a focus on ADGA API calls & Git operations
+
 ## 7.1.1-beta.5
 * Manually configured the commits for Sentry releases to align with the DigiGoat Releases versioning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.1-beta.5
+* Manually configured the commits for Sentry releases to align with the DigiGoat Releases versioning
+
 ## 7.1.1-beta.4
 * Added back an accidentally deleted script for the sourcemaps of the main process on MacOS
 * Updated release names to be Sentry compatible (i.e. `DigiGoat@7.1.1-beta.4` instead of just `7.1.1-beta.4`)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "7.1.1-beta.4",
+  "version": "7.1.1-beta.5",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "7.1.1-beta.5",
+  "version": "7.1.1-beta.6",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",

--- a/projects/main/src/main.ts
+++ b/projects/main/src/main.ts
@@ -12,6 +12,7 @@ init({
   environment: app.isPackaged ? (app.getVersion().includes('beta') ? 'beta' : 'production') : 'development',
   dist: process.platform === 'darwin' ? (process.arch === 'arm64' ? 'macos-arm64' : 'macos-x64') : 'windows',
   debug: !app.isPackaged,
+  tracesSampleRate: 1.0,
 });
 
 new AppModule();

--- a/projects/shared/shared.module.d.ts
+++ b/projects/shared/shared.module.d.ts
@@ -1,4 +1,4 @@
-import type { IpcMainEvent } from 'electron';
+import type { IpcMainInvokeEvent } from 'electron';
 import type { ADGAService } from './services/adga/adga.service';
 import type { AppService } from './services/app/app.service';
 import type { ConfigService } from './services/config/config.service';
@@ -30,7 +30,7 @@ export interface SharedModule {
 }
 
 type WithoutOnKeys<T> = {
-  [K in keyof T as K extends `on${infer _}` ? never : K]: T[K] extends (...args: infer A) => any ? (event: IpcMainEvent, ...args: A) => ReturnType<T[K]> : never;
+  [K in keyof T as K extends `on${infer _}` ? never : K]: T[K] extends (...args: infer A) => any ? (event: IpcMainInvokeEvent, ...args: A) => ReturnType<T[K]> : never;
 };
 
 type WithoutNonPromises<T> = {
@@ -39,6 +39,6 @@ type WithoutNonPromises<T> = {
 
 export type BackendService<T> = {
   //@ts-expect-error
-  [K in keyof WithoutOnKeys<WithoutNonPromises<T>>]: T[K] extends (...args: infer A) => any ? (event: IpcMainEvent, ...args: A) => ReturnType<T[K]> : never;
+  [K in keyof WithoutOnKeys<WithoutNonPromises<T>>]: T[K] extends (...args: infer A) => any ? (event: IpcMainInvokeEvent, ...args: A) => ReturnType<T[K]> : never;
 };
-export type BackendSharedModule = Record<keyof SharedModule, BackendService<SharedModule[keyof SharedModule]>>;
+export type BackendSharedModule = { [K in keyof SharedModule]: BackendService<SharedModule[K]> };


### PR DESCRIPTION
## 7.1.1-beta.6
* Started tracing all IPC calls with Sentry to help identify performance bottlenecks
  * With a focus on ADGA API calls & Git operations

## 7.1.1-beta.5
* Manually configured the commits for Sentry releases to align with the DigiGoat Releases versioning
