### PR TITLE
7.1.1-beta.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BEFORE: ${{ github.event.before }}
 
+      - name: Get First Commit Date
+        id: start_date
+        run: echo 'time=$(git show -s --format=%ct ${{ github.event.before }}' > $GITHUB_OUTPUT
+      
       - name: Create Sentry release
         uses: getsentry/action-release@v3
         with:
@@ -145,3 +149,4 @@ jobs:
           commit: ${{ github.sha }}
           previous_commit: ${{ github.event.before }}
           repo: DigiGoat/client-app
+          started_at: ${{ steps.start_date.outputs.time }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Get First Commit Date
         id: start_date
-        run: echo 'time=$(git show -s --format=%ct ${{ github.event.before }}' > $GITHUB_OUTPUT
+        run: echo 'time=$(git show -s --format=%ct ${{ github.event.before }}.. --reverse --ancestry-path -n 1)' > $GITHUB_OUTPUT
       
       - name: Create Sentry release
         uses: getsentry/action-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Get First Commit Date
         id: start_date
-        run: echo "time=$(git show -s --format=%ct ${{ github.event.before }}.. --reverse --ancestry-path -n 1)" > $GITHUB_OUTPUT
+        run: echo "time=$(git log -s --format=%ct ${{ github.event.before }}.. --reverse --ancestry-path -n 1)" >> $GITHUB_OUTPUT
 
       - name: Create Sentry release
         uses: getsentry/action-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,8 @@ jobs:
 
       - name: Get First Commit Date
         id: start_date
-        run: echo 'time=$(git show -s --format=%ct ${{ github.event.before }}.. --reverse --ancestry-path -n 1)' > $GITHUB_OUTPUT
-      
+        run: echo "time=$(git show -s --format=%ct ${{ github.event.before }}.. --reverse --ancestry-path -n 1)" > $GITHUB_OUTPUT
+
       - name: Create Sentry release
         uses: getsentry/action-release@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.1-beta.11
+* Release in sentry now show the "created at" date properly
+  * Uses the date of the first commit in the release range
+
 ## 7.1.1-beta.10
 * Changed the colors of the sentry feedback dialog to better match the DigiGoat theme
 * Removed some unnecessary Sentry integrations to improve performance

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "7.1.1-beta.10",
+  "version": "7.1.1-beta.11",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
## 7.1.1-beta.11
* Release in sentry now show the "created at" date properly
  * Uses the date of the first commit in the release range
