### PR TITLE
7.1.1-beta.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Get First Commit Date
         id: start_date
-        run: echo "time=$(git log -s --format=%ct ${{ github.event.before }}.. --reverse --ancestry-path -n 1)" >> $GITHUB_OUTPUT
+        run: echo "time=$(git log -s --format=%ct ${{ github.event.before }}.. --reverse -n 1)" >> $GITHUB_OUTPUT
 
       - name: Create Sentry release
         uses: getsentry/action-release@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.1.1-beta.12
+* (Hopefully) Fixed a bug causing the Sentry release date to be incorrect
+
 ## 7.1.1-beta.11
 * Release in sentry now show the "created at" date properly
   * Uses the date of the first commit in the release range

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/DigiGoat"
   },
   "description": "An app to merge the gap between ADGA, your farm, and the internet.",
-  "version": "7.1.1-beta.11",
+  "version": "7.1.1-beta.12",
   "main": "dist/main/main.js",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
## 7.1.1-beta.12
* (Hopefully) Fixed a bug causing the Sentry release date to be incorrect
